### PR TITLE
feat: add branding settings for white-label support

### DIFF
--- a/app/api/settings/route.ts
+++ b/app/api/settings/route.ts
@@ -1,15 +1,16 @@
 import { type NextRequest, NextResponse } from "next/server"
-import { getSetting, updateSetting } from "@/lib/db/queries"
+import { getSetting, updateSetting, getAllSettings } from "@/lib/db/queries"
 
 export async function GET(request: NextRequest) {
   try {
     const { searchParams } = new URL(request.url);
     const key = searchParams.get("key");
-    if (!key) {
-      return NextResponse.json({ error: "Missing 'key' query parameter" }, { status: 400 });
+    if (key) {
+      const setting = await getSetting(key);
+      return NextResponse.json(setting);
     }
-    const setting = await getSetting(key);
-    return NextResponse.json(setting);
+    const settings = await getAllSettings();
+    return NextResponse.json(settings);
   } catch (error) {
     console.error("Error fetching setting:", error);
     return NextResponse.json({ error: "Failed to fetch setting" }, { status: 500 });

--- a/components/admin/settings-management.tsx
+++ b/components/admin/settings-management.tsx
@@ -5,7 +5,7 @@ import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/com
 import { Button } from "@/components/ui/button"
 import { Input } from "@/components/ui/input"
 import { Textarea } from "@/components/ui/textarea"
-import { Save, Phone, MapPin, Clock, Calendar } from "lucide-react"
+import { Save, Phone, MapPin, Clock, Calendar, Palette } from "lucide-react"
 
 interface Setting {
   id: number
@@ -42,6 +42,13 @@ export function SettingsManagement() {
     end: "",
   })
   const [bookingAdvanceDays, setBookingAdvanceDays] = useState(30)
+  const [branding, setBranding] = useState({
+    companyName: "",
+    logoUrl: "",
+    primaryColor: "#000000",
+    secondaryColor: "#FFD700",
+    tagline: "",
+  })
 
   useEffect(() => {
     fetchSettings()
@@ -56,13 +63,36 @@ export function SettingsManagement() {
       data.forEach((setting: Setting) => {
         switch (setting.key) {
           case "contact_info":
-            setContactInfo(setting.value as ContactInfo)
+            try {
+              setContactInfo(JSON.parse(setting.value as string))
+            } catch {
+              /* ignore */
+            }
             break
           case "business_hours":
-            setBusinessHours(setting.value as BusinessHours)
+            try {
+              setBusinessHours(JSON.parse(setting.value as string))
+            } catch {
+              /* ignore */
+            }
             break
           case "booking_advance_days":
-            setBookingAdvanceDays(setting.value as number)
+            setBookingAdvanceDays(Number(setting.value))
+            break
+          case "company_name":
+            setBranding((b) => ({ ...b, companyName: String(setting.value) }))
+            break
+          case "logo_url":
+            setBranding((b) => ({ ...b, logoUrl: String(setting.value) }))
+            break
+          case "primary_color":
+            setBranding((b) => ({ ...b, primaryColor: String(setting.value) }))
+            break
+          case "secondary_color":
+            setBranding((b) => ({ ...b, secondaryColor: String(setting.value) }))
+            break
+          case "tagline":
+            setBranding((b) => ({ ...b, tagline: String(setting.value) }))
             break
         }
       })
@@ -86,6 +116,14 @@ export function SettingsManagement() {
     } finally {
       setSaving(false)
     }
+  }
+
+  const handleSaveBranding = async () => {
+    await saveSetting("company_name", branding.companyName, "Nombre de la empresa")
+    await saveSetting("logo_url", branding.logoUrl, "URL del logo")
+    await saveSetting("primary_color", branding.primaryColor, "Color primario")
+    await saveSetting("secondary_color", branding.secondaryColor, "Color secundario")
+    await saveSetting("tagline", branding.tagline, "Eslogan de la empresa")
   }
 
   const handleSaveContactInfo = () => {
@@ -129,6 +167,71 @@ export function SettingsManagement() {
       </div>
 
       <div className="grid grid-cols-1 lg:grid-cols-2 gap-8">
+        <Card className="bg-white border border-gray-200">
+          <CardHeader>
+            <CardTitle className="text-xl font-bold text-black flex items-center">
+              <Palette className="h-5 w-5 text-gold mr-3" />
+              Branding y Apariencia
+            </CardTitle>
+            <CardDescription>Personaliza la marca y los colores del sitio</CardDescription>
+          </CardHeader>
+          <CardContent className="space-y-6">
+            <div>
+              <label className="block text-sm font-medium text-gray-700 mb-2">Nombre de la Empresa</label>
+              <Input
+                value={branding.companyName}
+                onChange={(e) => setBranding({ ...branding, companyName: e.target.value })}
+                className="bg-gray-50 border-gray-200"
+              />
+            </div>
+            <div>
+              <label className="block text-sm font-medium text-gray-700 mb-2">URL del Logo</label>
+              <Input
+                value={branding.logoUrl}
+                onChange={(e) => setBranding({ ...branding, logoUrl: e.target.value })}
+                className="bg-gray-50 border-gray-200"
+              />
+            </div>
+            <div className="grid grid-cols-2 gap-4">
+              <div>
+                <label className="block text-sm font-medium text-gray-700 mb-2">Color Primario</label>
+                <Input
+                  type="color"
+                  value={branding.primaryColor}
+                  onChange={(e) => setBranding({ ...branding, primaryColor: e.target.value })}
+                  className="bg-gray-50 border-gray-200"
+                />
+              </div>
+              <div>
+                <label className="block text-sm font-medium text-gray-700 mb-2">Color Secundario</label>
+                <Input
+                  type="color"
+                  value={branding.secondaryColor}
+                  onChange={(e) => setBranding({ ...branding, secondaryColor: e.target.value })}
+                  className="bg-gray-50 border-gray-200"
+                />
+              </div>
+            </div>
+            <div>
+              <label className="block text-sm font-medium text-gray-700 mb-2">Eslogan</label>
+              <Textarea
+                value={branding.tagline}
+                onChange={(e) => setBranding({ ...branding, tagline: e.target.value })}
+                rows={2}
+                className="bg-gray-50 border-gray-200"
+              />
+            </div>
+            <Button
+              onClick={handleSaveBranding}
+              disabled={saving}
+              className="w-full bg-black text-white hover:bg-gold hover:text-black transition-all duration-300"
+            >
+              <Save className="h-4 w-4 mr-2" />
+              {saving ? "Guardando..." : "Guardar Branding"}
+            </Button>
+          </CardContent>
+        </Card>
+
         <Card className="bg-white border border-gray-200">
           <CardHeader>
             <CardTitle className="text-xl font-bold text-black flex items-center">

--- a/components/footer.tsx
+++ b/components/footer.tsx
@@ -39,10 +39,16 @@ const translations = {
 }
 
 export function Footer() {
-  const { language } = useApp()
+  const { language, settings } = useApp()
   const t = translations[language]
   const router = useRouter()
   const { isLoading, startLoading, stopLoading } = useNavigationLoading()
+
+  const companyName = settings.company_name || "OroBoats"
+  const logoSrc = settings.logo_url || "/assets/logo.png"
+  const tagline = settings.tagline || t.tagline
+  const contactEmail = settings.contact_email || "info@oroboats.com"
+  const contactPhone = settings.contact_phone || "+34 655 52 79 88"
 
   const handleNavigation = (path: string) => {
     startLoading()
@@ -57,26 +63,24 @@ export function Footer() {
   }
 
   return (
-    <footer className="bg-black text-white">
+    <footer className="bg-[var(--brand-primary)] text-white">
       <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-16">
         <div className="grid grid-cols-1 md:grid-cols-4 gap-8">
           <div className="col-span-1 md:col-span-2">
             <div className="flex items-center space-x-2 mb-4">
               {/* ✅ CAMBIO: Usar imagen en lugar del icono Ship */}
-              <Image src="/assets/logo.png" alt="OroBoats Logo" width={24} height={24} className="h-12 w-12" />
-              <span className="text-2xl font-bold">
-                Oro<span className="text-gold">Boats</span>
-              </span>
+              <Image src={logoSrc} alt={`${companyName} Logo`} width={24} height={24} className="h-12 w-12" />
+              <span className="text-2xl font-bold">{companyName}</span>
             </div>
-            <p className="text-gray-400 mb-6 max-w-md">{t.tagline}</p>
+            <p className="text-gray-400 mb-6 max-w-md">{tagline}</p>
             <div className="space-y-3">
               <div className="flex items-center space-x-3">
-                <Mail className="h-5 w-5 text-gold" />
-                <span className="text-gray-300">info@oroboats.com</span>
+                <Mail className="h-5 w-5 text-[var(--brand-secondary)]" />
+                <span className="text-gray-300">{contactEmail}</span>
               </div>
               <div className="flex items-center space-x-3">
-                <Phone className="h-5 w-5 text-gold" />
-                <span className="text-gray-300">+34 655 52 79 88</span>
+                <Phone className="h-5 w-5 text-[var(--brand-secondary)]" />
+                <span className="text-gray-300">{contactPhone}</span>
               </div>
             </div>
           </div>
@@ -87,7 +91,7 @@ export function Footer() {
               <li>
                 <button
                   onClick={() => handleNavigation("/about")}
-                  className="text-gray-400 hover:text-gold transition-colors duration-300 text-left"
+                  className="text-gray-400 hover:text-[var(--brand-secondary)] transition-colors duration-300 text-left"
                 >
                   {t.about}
                 </button>
@@ -95,7 +99,7 @@ export function Footer() {
               <li>
                 <button
                   onClick={() => handleNavigation("/contact")}
-                  className="text-gray-400 hover:text-gold transition-colors duration-300 text-left"
+                  className="text-gray-400 hover:text-[var(--brand-secondary)] transition-colors duration-300 text-left"
                 >
                   {t.contact}
                 </button>
@@ -103,7 +107,7 @@ export function Footer() {
               <li>
                 <button
                   onClick={() => handleNavigation("/privacy")}
-                  className="text-gray-400 hover:text-gold transition-colors duration-300 text-left"
+                  className="text-gray-400 hover:text-[var(--brand-secondary)] transition-colors duration-300 text-left"
                 >
                   {t.privacy}
                 </button>
@@ -111,7 +115,7 @@ export function Footer() {
               <li>
                 <button
                   onClick={() => handleNavigation("/terms")}
-                  className="text-gray-400 hover:text-gold transition-colors duration-300 text-left"
+                  className="text-gray-400 hover:text-[var(--brand-secondary)] transition-colors duration-300 text-left"
                 >
                   {t.terms}
                 </button>
@@ -125,7 +129,7 @@ export function Footer() {
               <li>
                 <button
                   onClick={() => handleNavigation("/boats?type=boats")}
-                  className="text-gray-400 hover:text-gold transition-colors duration-300 text-left"
+                  className="text-gray-400 hover:text-[var(--brand-secondary)] transition-colors duration-300 text-left"
                 >
                   {t.boats}
                 </button>
@@ -133,7 +137,7 @@ export function Footer() {
               <li>
                 <button
                   onClick={() => handleNavigation("/boats?type=jetskis")}
-                  className="text-gray-400 hover:text-gold transition-colors duration-300 text-left"
+                  className="text-gray-400 hover:text-[var(--brand-secondary)] transition-colors duration-300 text-left"
                 >
                   {t.jetskis}
                 </button>
@@ -141,7 +145,7 @@ export function Footer() {
               <li>
                 <button
                   onClick={() => handleNavigation("/fiestas")}
-                  className="text-gray-400 hover:text-gold transition-colors duration-300 text-left"
+                  className="text-gray-400 hover:text-[var(--brand-secondary)] transition-colors duration-300 text-left"
                 >
                   {t.parties}
                 </button>
@@ -149,7 +153,7 @@ export function Footer() {
               <li>
                 <button
                   onClick={() => handleNavigation("/boats")}
-                  className="text-gray-400 hover:text-gold transition-colors duration-300 text-left"
+                  className="text-gray-400 hover:text-[var(--brand-secondary)] transition-colors duration-300 text-left"
                 >
                   {t.booking}
                 </button>
@@ -161,20 +165,20 @@ export function Footer() {
         <div className="border-t border-gray-800 mt-12 pt-8">
           <div className="flex flex-col md:flex-row justify-between items-center">
             <p className="text-gray-400 mb-4 md:mb-0">
-              © {new Date().getFullYear()} OroBoats. {t.rights}
+              © {new Date().getFullYear()} {companyName}. {t.rights}
             </p>
 
             <div className="flex items-center space-x-6">
               <span className="text-gray-400 font-medium mr-4">{t.follow}</span>
               <a
                 href="https://www.facebook.com/oroboats/"
-                className="text-gray-400 hover:text-gold transition-colors duration-300"
+                className="text-gray-400 hover:text-[var(--brand-secondary)] transition-colors duration-300"
               >
                 <Facebook className="h-5 w-5" />
               </a>
               <a
                 href="https://www.instagram.com/oroboats"
-                className="text-gray-400 hover:text-gold transition-colors duration-300"
+                className="text-gray-400 hover:text-[var(--brand-secondary)] transition-colors duration-300"
               >
                 <Instagram className="h-5 w-5" />
               </a>

--- a/components/navigation.tsx
+++ b/components/navigation.tsx
@@ -24,10 +24,13 @@ const translations = {
 export function Navigation() {
   const [isOpen, setIsOpen] = useState(false)
   const [scrolled, setScrolled] = useState(false)
-  const { language, setLanguage } = useApp()
+  const { language, setLanguage, settings } = useApp()
   const { isLoading, startLoading, stopLoading } = useNavigationLoading()
   const router = useRouter()
   const t = translations[language]
+
+  const logoSrc = settings.logo_url || "/assets/negro.png"
+  const companyName = settings.company_name || "OroBoats"
 
   useEffect(() => {
     const handleScroll = () => {
@@ -74,8 +77,8 @@ export function Navigation() {
           <button onClick={handleLogoClick} className="flex items-center group cursor-pointer">
             <div className="relative h-8 w-auto flex items-center">
               <Image
-                src="/assets/negro.png"
-                alt="OroBoats Logo"
+                src={logoSrc}
+                alt={`${companyName} Logo`}
                 width={80}
                 height={32}
                 className="object-contain group-hover:scale-105 transition-transform duration-300"
@@ -88,20 +91,20 @@ export function Navigation() {
           <div className="hidden md:flex items-center space-x-8">
             <button
               onClick={() => handleNavigation("/")}
-              className="text-black hover:text-gold transition-colors duration-300 font-medium"
+              className="text-[var(--brand-primary)] hover:text-[var(--brand-secondary)] transition-colors duration-300 font-medium"
             >
               {t.home}
             </button>
             <button
               onClick={() => handleNavigation("/boats")}
-              className="text-black hover:text-gold transition-colors duration-300 font-medium"
+              className="text-[var(--brand-primary)] hover:text-[var(--brand-secondary)] transition-colors duration-300 font-medium"
             >
               {t.boats}
             </button>
             {/* ✅ NUEVO: Enlace al Blog */}
             <button
               onClick={() => handleNavigation("/blog")}
-              className="text-black hover:text-gold transition-colors duration-300 font-medium"
+              className="text-[var(--brand-primary)] hover:text-[var(--brand-secondary)] transition-colors duration-300 font-medium"
             >
               {t.blog}
             </button>
@@ -109,16 +112,16 @@ export function Navigation() {
             {/* Language Selector */}
             <DropdownMenu>
               <DropdownMenuTrigger asChild>
-                <Button variant="ghost" size="sm" className="text-black hover:text-gold hover:bg-gray-50">
+                <Button variant="ghost" size="sm" className="text-[var(--brand-primary)] hover:text-[var(--brand-secondary)] hover:bg-gray-50">
                   <Globe className="h-4 w-4 mr-2" />
                   {language.toUpperCase()}
                 </Button>
               </DropdownMenuTrigger>
               <DropdownMenuContent className="bg-white border-gray-200">
-                <DropdownMenuItem onClick={() => setLanguage("es")} className="text-black hover:bg-gray-50">
+                <DropdownMenuItem onClick={() => setLanguage("es")} className="text-[var(--brand-primary)] hover:bg-gray-50">
                   Español
                 </DropdownMenuItem>
-                <DropdownMenuItem onClick={() => setLanguage("en")} className="text-black hover:bg-gray-50">
+                <DropdownMenuItem onClick={() => setLanguage("en")} className="text-[var(--brand-primary)] hover:bg-gray-50">
                   English
                 </DropdownMenuItem>
               </DropdownMenuContent>
@@ -127,7 +130,12 @@ export function Navigation() {
 
           {/* Mobile menu button */}
           <div className="md:hidden">
-            <Button variant="ghost" size="sm" onClick={() => setIsOpen(!isOpen)} className="text-black hover:text-gold">
+            <Button
+              variant="ghost"
+              size="sm"
+              onClick={() => setIsOpen(!isOpen)}
+              className="text-[var(--brand-primary)] hover:text-[var(--brand-secondary)]"
+            >
               {isOpen ? <X className="h-6 w-6" /> : <Menu className="h-6 w-6" />}
             </Button>
           </div>
@@ -139,20 +147,20 @@ export function Navigation() {
             <div className="px-2 pt-2 pb-3 space-y-1">
               <button
                 onClick={() => handleNavigation("/")}
-                className="block w-full text-left px-3 py-2 text-black hover:text-gold transition-colors"
+                className="block w-full text-left px-3 py-2 text-[var(--brand-primary)] hover:text-[var(--brand-secondary)] transition-colors"
               >
                 {t.home}
               </button>
               <button
                 onClick={() => handleNavigation("/boats")}
-                className="block w-full text-left px-3 py-2 text-black hover:text-gold transition-colors"
+                className="block w-full text-left px-3 py-2 text-[var(--brand-primary)] hover:text-[var(--brand-secondary)] transition-colors"
               >
                 {t.boats}
               </button>
               {/* ✅ NUEVO: Enlace al Blog en móvil */}
               <button
                 onClick={() => handleNavigation("/blog")}
-                className="block w-full text-left px-3 py-2 text-black hover:text-gold transition-colors"
+                className="block w-full text-left px-3 py-2 text-[var(--brand-primary)] hover:text-[var(--brand-secondary)] transition-colors"
               >
                 {t.blog}
               </button>
@@ -164,21 +172,21 @@ export function Navigation() {
                     <Button
                       variant="ghost"
                       size="sm"
-                      className="text-black hover:text-gold hover:bg-gray-50 w-full justify-start"
-                    >
-                      <Globe className="h-4 w-4 mr-2" />
-                      {language.toUpperCase()}
-                    </Button>
-                  </DropdownMenuTrigger>
-                  <DropdownMenuContent className="bg-white border-gray-200">
-                    <DropdownMenuItem onClick={() => setLanguage("es")} className="text-black hover:bg-gray-50">
+                    className="text-[var(--brand-primary)] hover:text-[var(--brand-secondary)] hover:bg-gray-50 w-full justify-start"
+                  >
+                    <Globe className="h-4 w-4 mr-2" />
+                    {language.toUpperCase()}
+                  </Button>
+                </DropdownMenuTrigger>
+                <DropdownMenuContent className="bg-white border-gray-200">
+                    <DropdownMenuItem onClick={() => setLanguage("es")} className="text-[var(--brand-primary)] hover:bg-gray-50">
                       Español
                     </DropdownMenuItem>
-                    <DropdownMenuItem onClick={() => setLanguage("en")} className="text-black hover:bg-gray-50">
+                    <DropdownMenuItem onClick={() => setLanguage("en")} className="text-[var(--brand-primary)] hover:bg-gray-50">
                       English
                     </DropdownMenuItem>
-                  </DropdownMenuContent>
-                </DropdownMenu>
+                </DropdownMenuContent>
+              </DropdownMenu>
               </div>
             </div>
           </div>

--- a/lib/db/queries.ts
+++ b/lib/db/queries.ts
@@ -285,12 +285,15 @@ export async function getSetting(key: string) {
 }
 
 export async function updateSetting(key: string, value: unknown, description?: string) {
+  const serialized =
+    typeof value === "string" ? value : value === undefined ? "" : JSON.stringify(value)
+
   return await db
     .insert(settings)
-    .values({ key, value: value === undefined ? "" : String(value), description })
+    .values({ key, value: serialized, description })
     .onConflictDoUpdate({
       target: settings.key,
-      set: { value: value === undefined ? "" : String(value), updatedAt: new Date() },
+      set: { value: serialized, updatedAt: new Date() },
     })
 }
 


### PR DESCRIPTION
## Summary
- add API and DB support for editable settings
- expose branding settings in admin dashboard
- use dynamic logo and colors in navigation and footer

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: many ESLint errors)*

------
https://chatgpt.com/codex/tasks/task_e_68b639758f0c83319cbf2f3bad73ea36