### PR TITLE
feat: random themed blog images

### DIFF
--- a/components/admin/blog-management.tsx
+++ b/components/admin/blog-management.tsx
@@ -14,6 +14,9 @@ import { Switch } from "@/components/ui/switch"
 import { PlusCircle, Trash2, Search, Edit, Eye, Star, Calendar, Clock, FileText, Save, X } from "lucide-react"
 import type { BlogPost, NewBlogPost } from "@/lib/db/schema"
 
+const getRandomImage = () =>
+  `https://loremflickr.com/800/600/boat,beach,summer?random=${Math.random()}`
+
 type BlogManagementProps = {}
 
 export function BlogManagement({}: BlogManagementProps) {
@@ -30,7 +33,7 @@ export function BlogManagement({}: BlogManagementProps) {
     title: "",
     excerpt: "",
     content: "",
-    featuredImage: "",
+    featuredImage: getRandomImage(),
     language: "es",
     isFeatured: false,
     isPublished: false,
@@ -121,7 +124,7 @@ export function BlogManagement({}: BlogManagementProps) {
       title: post.title,
       excerpt: post.excerpt,
       content: post.content,
-      featuredImage: post.featuredImage || "",
+      featuredImage: post.featuredImage || getRandomImage(),
       language: post.language,
       isFeatured: post.isFeatured,
       isPublished: post.isPublished,
@@ -139,7 +142,7 @@ export function BlogManagement({}: BlogManagementProps) {
       title: "",
       excerpt: "",
       content: "",
-      featuredImage: "",
+      featuredImage: getRandomImage(),
       language: "es",
       isFeatured: false,
       isPublished: false,
@@ -261,12 +264,21 @@ export function BlogManagement({}: BlogManagementProps) {
 
               <div>
                 <Label htmlFor="featuredImage">Imagen Destacada (URL)</Label>
-                <Input
-                  id="featuredImage"
-                  value={formData.featuredImage || ""}
-                  onChange={(e) => setFormData({ ...formData, featuredImage: e.target.value })}
-                  placeholder="https://ejemplo.com/imagen.jpg"
-                />
+                <div className="flex gap-2">
+                  <Input
+                    id="featuredImage"
+                    value={formData.featuredImage || ""}
+                    onChange={(e) => setFormData({ ...formData, featuredImage: e.target.value })}
+                    placeholder="https://ejemplo.com/imagen.jpg"
+                  />
+                  <Button
+                    type="button"
+                    variant="outline"
+                    onClick={() => setFormData({ ...formData, featuredImage: getRandomImage() })}
+                  >
+                    Aleatoria
+                  </Button>
+                </div>
               </div>
 
               <div className="grid grid-cols-1 md:grid-cols-2 gap-4">

--- a/lib/db/schema-blog-update.ts
+++ b/lib/db/schema-blog-update.ts
@@ -10,7 +10,7 @@ export const blogPosts = pgTable("blog_posts", {
   slug: text("slug").unique().notNull(), // URL amigable
   excerpt: text("excerpt").notNull(), // Resumen corto
   content: text("content").notNull(), // Contenido completo en markdown/HTML
-  featuredImage: text("featured_image"), // URL de imagen destacada
+  featuredImage: text("featured_image").default("https://loremflickr.com/800/600/boat,beach,summer"), // URL de imagen destacada
   language: varchar("language", { length: 2 }).notNull().default("es"), // 'es' | 'en'
   isFeatured: boolean("is_featured").default(false), // Solo uno puede ser featured por idioma
   isPublished: boolean("is_published").default(false),


### PR DESCRIPTION
## Summary
- generate random boat and beach images for blog posts
- default blog post schema to themed random images

## Testing
- `npm test` (fails: Missing script: "test")
- `npm run lint` (fails: multiple lint errors)


------
https://chatgpt.com/codex/tasks/task_e_68b638f1e1c0833181d77da3bb578023