### PR TITLE
feat: configurable button palettes and backgrounds

### DIFF
--- a/app/api/settings/route.ts
+++ b/app/api/settings/route.ts
@@ -1,15 +1,16 @@
 import { type NextRequest, NextResponse } from "next/server"
-import { getSetting, updateSetting } from "@/lib/db/queries"
+import { getSetting, updateSetting, getAllSettings } from "@/lib/db/queries"
 
 export async function GET(request: NextRequest) {
   try {
     const { searchParams } = new URL(request.url);
     const key = searchParams.get("key");
-    if (!key) {
-      return NextResponse.json({ error: "Missing 'key' query parameter" }, { status: 400 });
+    if (key) {
+      const setting = await getSetting(key);
+      return NextResponse.json(setting);
     }
-    const setting = await getSetting(key);
-    return NextResponse.json(setting);
+    const settings = await getAllSettings();
+    return NextResponse.json(settings);
   } catch (error) {
     console.error("Error fetching setting:", error);
     return NextResponse.json({ error: "Failed to fetch setting" }, { status: 500 });

--- a/app/globals.css
+++ b/app/globals.css
@@ -24,6 +24,10 @@
     --input: 214.3 31.8% 91.4%;
     --ring: 221.2 83.2% 53.3%;
     --radius: 0.5rem;
+    --brand-primary: #000000;
+    --brand-secondary: #FFD700;
+    --brand-background: #FFFFFF;
+    --brand-loading-background: #FFFFFF;
   }
 
   .dark {
@@ -54,7 +58,7 @@
     border-color: hsl(var(--border));
   }
   body {
-    background-color: hsl(var(--background));
+    background-color: var(--brand-background);
     color: hsl(var(--foreground));
   }
 }
@@ -65,27 +69,70 @@
   }
 
   .text-gold {
-    color: #ffd700;
+    color: var(--brand-secondary);
   }
 
   .bg-gold {
-    background-color: #ffd700;
+    background-color: var(--brand-secondary);
   }
 
   .border-gold {
-    border-color: #ffd700;
+    border-color: var(--brand-secondary);
+  }
+
+  .border-black {
+    border-color: var(--brand-primary) !important;
+  }
+  .hover\:border-gold:hover {
+    border-color: var(--brand-secondary) !important;
   }
 
   .from-gold {
-    --tw-gradient-from: #ffd700;
+    --tw-gradient-from: var(--brand-secondary);
   }
 
   .to-gold {
-    --tw-gradient-to: #ffd700;
+    --tw-gradient-to: var(--brand-secondary);
   }
 
   .shadow-gold {
-    --tw-shadow-color: #ffd700;
+    --tw-shadow-color: var(--brand-secondary);
+  }
+
+  .btn-primary {
+    background-color: var(--brand-primary);
+    color: #fff;
+  }
+  .btn-primary:hover {
+    background-color: var(--brand-secondary);
+    color: #000;
+  }
+
+  .btn-secondary {
+    background-color: var(--brand-secondary);
+    color: #000;
+  }
+  .btn-secondary:hover {
+    background-color: var(--brand-primary);
+    color: #fff;
+  }
+
+  /* Override legacy color classes to use brand variables */
+  .bg-black {
+    background-color: var(--brand-primary) !important;
+  }
+  .hover\:bg-black:hover {
+    background-color: var(--brand-primary) !important;
+  }
+  .bg-gold,
+  .bg-yellow-300,
+  .bg-yellow-400 {
+    background-color: var(--brand-secondary) !important;
+  }
+  .hover\:bg-gold:hover,
+  .hover\:bg-yellow-300:hover,
+  .hover\:bg-yellow-400:hover {
+    background-color: var(--brand-secondary) !important;
   }
 }
 

--- a/components/admin/settings-management.tsx
+++ b/components/admin/settings-management.tsx
@@ -5,7 +5,8 @@ import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/com
 import { Button } from "@/components/ui/button"
 import { Input } from "@/components/ui/input"
 import { Textarea } from "@/components/ui/textarea"
-import { Save, Phone, MapPin, Clock, Calendar } from "lucide-react"
+import { ImageUpload } from "@/components/admin/image-upload"
+import { Save, Phone, MapPin, Clock, Calendar, Palette, RotateCcw } from "lucide-react"
 
 interface Setting {
   id: number
@@ -42,6 +43,16 @@ export function SettingsManagement() {
     end: "",
   })
   const [bookingAdvanceDays, setBookingAdvanceDays] = useState(30)
+    const defaultBranding = {
+      companyName: "OroBoats",
+      logoUrl: "/assets/negro.png",
+      primaryColor: "#000000",
+      secondaryColor: "#FFD700",
+      backgroundColor: "#FFFFFF",
+      loadingBackgroundColor: "#FFFFFF",
+      tagline: "",
+    }
+  const [branding, setBranding] = useState({ ...defaultBranding })
 
   useEffect(() => {
     fetchSettings()
@@ -56,13 +67,42 @@ export function SettingsManagement() {
       data.forEach((setting: Setting) => {
         switch (setting.key) {
           case "contact_info":
-            setContactInfo(setting.value as ContactInfo)
+            try {
+              setContactInfo(JSON.parse(setting.value as string))
+            } catch {
+              /* ignore */
+            }
             break
           case "business_hours":
-            setBusinessHours(setting.value as BusinessHours)
+            try {
+              setBusinessHours(JSON.parse(setting.value as string))
+            } catch {
+              /* ignore */
+            }
             break
           case "booking_advance_days":
-            setBookingAdvanceDays(setting.value as number)
+            setBookingAdvanceDays(Number(setting.value))
+            break
+          case "company_name":
+            setBranding((b) => ({ ...b, companyName: String(setting.value) }))
+            break
+          case "logo_url":
+            setBranding((b) => ({ ...b, logoUrl: String(setting.value) }))
+            break
+          case "primary_color":
+            setBranding((b) => ({ ...b, primaryColor: String(setting.value) }))
+            break
+          case "secondary_color":
+            setBranding((b) => ({ ...b, secondaryColor: String(setting.value) }))
+            break
+          case "background_color":
+            setBranding((b) => ({ ...b, backgroundColor: String(setting.value) }))
+            break
+          case "loading_background_color":
+            setBranding((b) => ({ ...b, loadingBackgroundColor: String(setting.value) }))
+            break
+          case "tagline":
+            setBranding((b) => ({ ...b, tagline: String(setting.value) }))
             break
         }
       })
@@ -87,6 +127,31 @@ export function SettingsManagement() {
       setSaving(false)
     }
   }
+
+  const handleSaveBranding = async () => {
+    await saveSetting("company_name", branding.companyName, "Nombre de la empresa")
+    await saveSetting("logo_url", branding.logoUrl, "URL del logo")
+      await saveSetting("primary_color", branding.primaryColor, "Color primario")
+      await saveSetting("secondary_color", branding.secondaryColor, "Color secundario")
+      await saveSetting("background_color", branding.backgroundColor, "Color de fondo")
+      await saveSetting("loading_background_color", branding.loadingBackgroundColor, "Color de fondo de carga")
+      await saveSetting("tagline", branding.tagline, "Eslogan de la empresa")
+    }
+
+  const handleResetBranding = async () => {
+    setBranding({ ...defaultBranding })
+    await saveSetting("company_name", defaultBranding.companyName, "Nombre de la empresa")
+    await saveSetting("logo_url", defaultBranding.logoUrl, "URL del logo")
+      await saveSetting("primary_color", defaultBranding.primaryColor, "Color primario")
+      await saveSetting("secondary_color", defaultBranding.secondaryColor, "Color secundario")
+      await saveSetting("background_color", defaultBranding.backgroundColor, "Color de fondo")
+      await saveSetting(
+        "loading_background_color",
+        defaultBranding.loadingBackgroundColor,
+        "Color de fondo de carga",
+      )
+      await saveSetting("tagline", defaultBranding.tagline, "Eslogan de la empresa")
+    }
 
   const handleSaveContactInfo = () => {
     saveSetting("contact_info", contactInfo, "Información de contacto del negocio")
@@ -132,6 +197,103 @@ export function SettingsManagement() {
         <Card className="bg-white border border-gray-200">
           <CardHeader>
             <CardTitle className="text-xl font-bold text-black flex items-center">
+              <Palette className="h-5 w-5 text-gold mr-3" />
+              Branding y Apariencia
+            </CardTitle>
+            <CardDescription>Personaliza la marca y los colores del sitio</CardDescription>
+          </CardHeader>
+          <CardContent className="space-y-6">
+            <div>
+              <label className="block text-sm font-medium text-gray-700 mb-2">Nombre de la Empresa</label>
+              <Input
+                value={branding.companyName}
+                onChange={(e) => setBranding({ ...branding, companyName: e.target.value })}
+                className="bg-gray-50 border-gray-200"
+              />
+            </div>
+            <div>
+              <label className="block text-sm font-medium text-gray-700 mb-2">Logo</label>
+              <ImageUpload
+                value={branding.logoUrl}
+                onChange={(url) => setBranding({ ...branding, logoUrl: url })}
+                vehicleType="boat"
+              />
+            </div>
+              <div className="grid grid-cols-2 gap-4">
+                <div>
+                  <label className="block text-sm font-medium text-gray-700 mb-2">Color Botón 1</label>
+                  <Input
+                    type="color"
+                    value={branding.primaryColor}
+                    onChange={(e) => setBranding({ ...branding, primaryColor: e.target.value })}
+                    className="bg-gray-50 border-gray-200"
+                  />
+                </div>
+                <div>
+                  <label className="block text-sm font-medium text-gray-700 mb-2">Color Botón 2</label>
+                  <Input
+                    type="color"
+                    value={branding.secondaryColor}
+                    onChange={(e) => setBranding({ ...branding, secondaryColor: e.target.value })}
+                    className="bg-gray-50 border-gray-200"
+                  />
+                </div>
+              </div>
+              <div className="grid grid-cols-2 gap-4">
+                <div>
+                  <label className="block text-sm font-medium text-gray-700 mb-2">Background 1</label>
+                  <Input
+                    type="color"
+                    value={branding.loadingBackgroundColor}
+                    onChange={(e) =>
+                      setBranding({ ...branding, loadingBackgroundColor: e.target.value })
+                    }
+                    className="bg-gray-50 border-gray-200"
+                  />
+                </div>
+                <div>
+                  <label className="block text-sm font-medium text-gray-700 mb-2">Background 2</label>
+                  <Input
+                    type="color"
+                    value={branding.backgroundColor}
+                    onChange={(e) => setBranding({ ...branding, backgroundColor: e.target.value })}
+                    className="bg-gray-50 border-gray-200"
+                  />
+                </div>
+              </div>
+            <div>
+              <label className="block text-sm font-medium text-gray-700 mb-2">Eslogan</label>
+              <Textarea
+                value={branding.tagline}
+                onChange={(e) => setBranding({ ...branding, tagline: e.target.value })}
+                rows={2}
+                className="bg-gray-50 border-gray-200"
+              />
+            </div>
+              <div className="space-y-2">
+                <Button
+                  onClick={handleSaveBranding}
+                  disabled={saving}
+                  className="w-full btn-primary transition-all duration-300"
+                >
+                  <Save className="h-4 w-4 mr-2" />
+                  {saving ? "Guardando..." : "Guardar Branding"}
+                </Button>
+                <Button
+                  type="button"
+                  onClick={handleResetBranding}
+                  className="w-full border-gray-300 hover:border-gold hover:bg-gold/10 text-black"
+                >
+                  <RotateCcw className="h-4 w-4 mr-2" />
+                  Restablecer de Fábrica
+                </Button>
+              </div>
+          </CardContent>
+        </Card>
+
+        <Card className="bg-white border border-gray-200">
+          <CardHeader>
+            <CardTitle className="text-xl font-bold text-black flex items-center">
               <Phone className="h-5 w-5 text-gold mr-3" />
               Información de Contacto
             </CardTitle>
@@ -173,7 +335,7 @@ export function SettingsManagement() {
             <Button
               onClick={handleSaveContactInfo}
               disabled={saving}
-              className="w-full bg-black text-white hover:bg-gold hover:text-black transition-all duration-300"
+              className="w-full btn-primary transition-all duration-300"
             >
               <Save className="h-4 w-4 mr-2" />
               {saving ? "Guardando..." : "Guardar Contacto"}
@@ -222,7 +384,7 @@ export function SettingsManagement() {
             <Button
               onClick={handleSaveBusinessHours}
               disabled={saving}
-              className="w-full bg-black text-white hover:bg-gold hover:text-black transition-all duration-300"
+              className="w-full btn-primary transition-all duration-300"
             >
               <Save className="h-4 w-4 mr-2" />
               {saving ? "Guardando..." : "Guardar Horarios"}
@@ -259,7 +421,7 @@ export function SettingsManagement() {
             <Button
               onClick={handleSaveBookingAdvance}
               disabled={saving}
-              className="w-full bg-black text-white hover:bg-gold hover:text-black transition-all duration-300"
+              className="w-full btn-primary transition-all duration-300"
             >
               <Save className="h-4 w-4 mr-2" />
               {saving ? "Guardando..." : "Guardar Configuración"}

--- a/components/footer.tsx
+++ b/components/footer.tsx
@@ -39,10 +39,16 @@ const translations = {
 }
 
 export function Footer() {
-  const { language } = useApp()
+  const { language, settings } = useApp()
   const t = translations[language]
   const router = useRouter()
   const { isLoading, startLoading, stopLoading } = useNavigationLoading()
+
+  const companyName = settings.company_name || "OroBoats"
+  const logoSrc = settings.logo_url || "/assets/logo.png"
+  const tagline = settings.tagline || t.tagline
+  const contactEmail = settings.contact_email || "info@oroboats.com"
+  const contactPhone = settings.contact_phone || "+34 655 52 79 88"
 
   const handleNavigation = (path: string) => {
     startLoading()
@@ -57,26 +63,24 @@ export function Footer() {
   }
 
   return (
-    <footer className="bg-black text-white">
+    <footer className="bg-[var(--brand-primary)] text-white">
       <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-16">
         <div className="grid grid-cols-1 md:grid-cols-4 gap-8">
           <div className="col-span-1 md:col-span-2">
             <div className="flex items-center space-x-2 mb-4">
               {/* ✅ CAMBIO: Usar imagen en lugar del icono Ship */}
-              <Image src="/assets/logo.png" alt="OroBoats Logo" width={24} height={24} className="h-12 w-12" />
-              <span className="text-2xl font-bold">
-                Oro<span className="text-gold">Boats</span>
-              </span>
+              <Image src={logoSrc} alt={`${companyName} Logo`} width={24} height={24} className="h-12 w-12" />
+              <span className="text-2xl font-bold">{companyName}</span>
             </div>
-            <p className="text-gray-400 mb-6 max-w-md">{t.tagline}</p>
+            <p className="text-gray-400 mb-6 max-w-md">{tagline}</p>
             <div className="space-y-3">
               <div className="flex items-center space-x-3">
-                <Mail className="h-5 w-5 text-gold" />
-                <span className="text-gray-300">info@oroboats.com</span>
+                <Mail className="h-5 w-5 text-[var(--brand-secondary)]" />
+                <span className="text-gray-300">{contactEmail}</span>
               </div>
               <div className="flex items-center space-x-3">
-                <Phone className="h-5 w-5 text-gold" />
-                <span className="text-gray-300">+34 655 52 79 88</span>
+                <Phone className="h-5 w-5 text-[var(--brand-secondary)]" />
+                <span className="text-gray-300">{contactPhone}</span>
               </div>
             </div>
           </div>
@@ -87,7 +91,7 @@ export function Footer() {
               <li>
                 <button
                   onClick={() => handleNavigation("/about")}
-                  className="text-gray-400 hover:text-gold transition-colors duration-300 text-left"
+                  className="text-gray-400 hover:text-[var(--brand-secondary)] transition-colors duration-300 text-left"
                 >
                   {t.about}
                 </button>
@@ -95,7 +99,7 @@ export function Footer() {
               <li>
                 <button
                   onClick={() => handleNavigation("/contact")}
-                  className="text-gray-400 hover:text-gold transition-colors duration-300 text-left"
+                  className="text-gray-400 hover:text-[var(--brand-secondary)] transition-colors duration-300 text-left"
                 >
                   {t.contact}
                 </button>
@@ -103,7 +107,7 @@ export function Footer() {
               <li>
                 <button
                   onClick={() => handleNavigation("/privacy")}
-                  className="text-gray-400 hover:text-gold transition-colors duration-300 text-left"
+                  className="text-gray-400 hover:text-[var(--brand-secondary)] transition-colors duration-300 text-left"
                 >
                   {t.privacy}
                 </button>
@@ -111,7 +115,7 @@ export function Footer() {
               <li>
                 <button
                   onClick={() => handleNavigation("/terms")}
-                  className="text-gray-400 hover:text-gold transition-colors duration-300 text-left"
+                  className="text-gray-400 hover:text-[var(--brand-secondary)] transition-colors duration-300 text-left"
                 >
                   {t.terms}
                 </button>
@@ -125,7 +129,7 @@ export function Footer() {
               <li>
                 <button
                   onClick={() => handleNavigation("/boats?type=boats")}
-                  className="text-gray-400 hover:text-gold transition-colors duration-300 text-left"
+                  className="text-gray-400 hover:text-[var(--brand-secondary)] transition-colors duration-300 text-left"
                 >
                   {t.boats}
                 </button>
@@ -133,7 +137,7 @@ export function Footer() {
               <li>
                 <button
                   onClick={() => handleNavigation("/boats?type=jetskis")}
-                  className="text-gray-400 hover:text-gold transition-colors duration-300 text-left"
+                  className="text-gray-400 hover:text-[var(--brand-secondary)] transition-colors duration-300 text-left"
                 >
                   {t.jetskis}
                 </button>
@@ -141,7 +145,7 @@ export function Footer() {
               <li>
                 <button
                   onClick={() => handleNavigation("/fiestas")}
-                  className="text-gray-400 hover:text-gold transition-colors duration-300 text-left"
+                  className="text-gray-400 hover:text-[var(--brand-secondary)] transition-colors duration-300 text-left"
                 >
                   {t.parties}
                 </button>
@@ -149,7 +153,7 @@ export function Footer() {
               <li>
                 <button
                   onClick={() => handleNavigation("/boats")}
-                  className="text-gray-400 hover:text-gold transition-colors duration-300 text-left"
+                  className="text-gray-400 hover:text-[var(--brand-secondary)] transition-colors duration-300 text-left"
                 >
                   {t.booking}
                 </button>
@@ -161,20 +165,20 @@ export function Footer() {
         <div className="border-t border-gray-800 mt-12 pt-8">
           <div className="flex flex-col md:flex-row justify-between items-center">
             <p className="text-gray-400 mb-4 md:mb-0">
-              © {new Date().getFullYear()} OroBoats. {t.rights}
+              © {new Date().getFullYear()} {companyName}. {t.rights}
             </p>
 
             <div className="flex items-center space-x-6">
               <span className="text-gray-400 font-medium mr-4">{t.follow}</span>
               <a
                 href="https://www.facebook.com/oroboats/"
-                className="text-gray-400 hover:text-gold transition-colors duration-300"
+                className="text-gray-400 hover:text-[var(--brand-secondary)] transition-colors duration-300"
               >
                 <Facebook className="h-5 w-5" />
               </a>
               <a
                 href="https://www.instagram.com/oroboats"
-                className="text-gray-400 hover:text-gold transition-colors duration-300"
+                className="text-gray-400 hover:text-[var(--brand-secondary)] transition-colors duration-300"
               >
                 <Instagram className="h-5 w-5" />
               </a>

--- a/components/navigation.tsx
+++ b/components/navigation.tsx
@@ -24,10 +24,13 @@ const translations = {
 export function Navigation() {
   const [isOpen, setIsOpen] = useState(false)
   const [scrolled, setScrolled] = useState(false)
-  const { language, setLanguage } = useApp()
+  const { language, setLanguage, settings } = useApp()
   const { isLoading, startLoading, stopLoading } = useNavigationLoading()
   const router = useRouter()
   const t = translations[language]
+
+  const logoSrc = settings.logo_url || "/assets/negro.png"
+  const companyName = settings.company_name || "OroBoats"
 
   useEffect(() => {
     const handleScroll = () => {
@@ -65,7 +68,9 @@ export function Navigation() {
   return (
     <nav
       className={`fixed top-0 w-full z-50 transition-all duration-300 ${
-        scrolled ? "bg-white/95 backdrop-blur-md border-b border-gray-200 shadow-sm" : "bg-white"
+        scrolled
+          ? "bg-[color:var(--brand-background)/0.95] backdrop-blur-md border-b border-gray-200 shadow-sm"
+          : "bg-[var(--brand-background)]"
       }`}
     >
       <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
@@ -74,8 +79,8 @@ export function Navigation() {
           <button onClick={handleLogoClick} className="flex items-center group cursor-pointer">
             <div className="relative h-8 w-auto flex items-center">
               <Image
-                src="/assets/negro.png"
-                alt="OroBoats Logo"
+                src={logoSrc}
+                alt={`${companyName} Logo`}
                 width={80}
                 height={32}
                 className="object-contain group-hover:scale-105 transition-transform duration-300"
@@ -88,20 +93,20 @@ export function Navigation() {
           <div className="hidden md:flex items-center space-x-8">
             <button
               onClick={() => handleNavigation("/")}
-              className="text-black hover:text-gold transition-colors duration-300 font-medium"
+              className="text-[var(--brand-primary)] hover:text-[var(--brand-secondary)] transition-colors duration-300 font-medium"
             >
               {t.home}
             </button>
             <button
               onClick={() => handleNavigation("/boats")}
-              className="text-black hover:text-gold transition-colors duration-300 font-medium"
+              className="text-[var(--brand-primary)] hover:text-[var(--brand-secondary)] transition-colors duration-300 font-medium"
             >
               {t.boats}
             </button>
             {/* ✅ NUEVO: Enlace al Blog */}
             <button
               onClick={() => handleNavigation("/blog")}
-              className="text-black hover:text-gold transition-colors duration-300 font-medium"
+              className="text-[var(--brand-primary)] hover:text-[var(--brand-secondary)] transition-colors duration-300 font-medium"
             >
               {t.blog}
             </button>
@@ -109,16 +114,16 @@ export function Navigation() {
             {/* Language Selector */}
             <DropdownMenu>
               <DropdownMenuTrigger asChild>
-                <Button variant="ghost" size="sm" className="text-black hover:text-gold hover:bg-gray-50">
+                <Button variant="ghost" size="sm" className="text-[var(--brand-primary)] hover:text-[var(--brand-secondary)] hover:bg-gray-50">
                   <Globe className="h-4 w-4 mr-2" />
                   {language.toUpperCase()}
                 </Button>
               </DropdownMenuTrigger>
-              <DropdownMenuContent className="bg-white border-gray-200">
-                <DropdownMenuItem onClick={() => setLanguage("es")} className="text-black hover:bg-gray-50">
+              <DropdownMenuContent className="bg-[var(--brand-background)] border-gray-200">
+                <DropdownMenuItem onClick={() => setLanguage("es")} className="text-[var(--brand-primary)] hover:bg-gray-50">
                   Español
                 </DropdownMenuItem>
-                <DropdownMenuItem onClick={() => setLanguage("en")} className="text-black hover:bg-gray-50">
+                <DropdownMenuItem onClick={() => setLanguage("en")} className="text-[var(--brand-primary)] hover:bg-gray-50">
                   English
                 </DropdownMenuItem>
               </DropdownMenuContent>
@@ -127,7 +132,12 @@ export function Navigation() {
 
           {/* Mobile menu button */}
           <div className="md:hidden">
-            <Button variant="ghost" size="sm" onClick={() => setIsOpen(!isOpen)} className="text-black hover:text-gold">
+            <Button
+              variant="ghost"
+              size="sm"
+              onClick={() => setIsOpen(!isOpen)}
+              className="text-[var(--brand-primary)] hover:text-[var(--brand-secondary)]"
+            >
               {isOpen ? <X className="h-6 w-6" /> : <Menu className="h-6 w-6" />}
             </Button>
           </div>
@@ -135,24 +145,24 @@ export function Navigation() {
 
         {/* Mobile Navigation */}
         {isOpen && (
-          <div className="md:hidden bg-white border-t border-gray-200">
+          <div className="md:hidden bg-[var(--brand-background)] border-t border-gray-200">
             <div className="px-2 pt-2 pb-3 space-y-1">
               <button
                 onClick={() => handleNavigation("/")}
-                className="block w-full text-left px-3 py-2 text-black hover:text-gold transition-colors"
+                className="block w-full text-left px-3 py-2 text-[var(--brand-primary)] hover:text-[var(--brand-secondary)] transition-colors"
               >
                 {t.home}
               </button>
               <button
                 onClick={() => handleNavigation("/boats")}
-                className="block w-full text-left px-3 py-2 text-black hover:text-gold transition-colors"
+                className="block w-full text-left px-3 py-2 text-[var(--brand-primary)] hover:text-[var(--brand-secondary)] transition-colors"
               >
                 {t.boats}
               </button>
               {/* ✅ NUEVO: Enlace al Blog en móvil */}
               <button
                 onClick={() => handleNavigation("/blog")}
-                className="block w-full text-left px-3 py-2 text-black hover:text-gold transition-colors"
+                className="block w-full text-left px-3 py-2 text-[var(--brand-primary)] hover:text-[var(--brand-secondary)] transition-colors"
               >
                 {t.blog}
               </button>
@@ -164,21 +174,21 @@ export function Navigation() {
                     <Button
                       variant="ghost"
                       size="sm"
-                      className="text-black hover:text-gold hover:bg-gray-50 w-full justify-start"
-                    >
-                      <Globe className="h-4 w-4 mr-2" />
-                      {language.toUpperCase()}
-                    </Button>
-                  </DropdownMenuTrigger>
-                  <DropdownMenuContent className="bg-white border-gray-200">
-                    <DropdownMenuItem onClick={() => setLanguage("es")} className="text-black hover:bg-gray-50">
+                    className="text-[var(--brand-primary)] hover:text-[var(--brand-secondary)] hover:bg-gray-50 w-full justify-start"
+                  >
+                    <Globe className="h-4 w-4 mr-2" />
+                    {language.toUpperCase()}
+                  </Button>
+                </DropdownMenuTrigger>
+                <DropdownMenuContent className="bg-[var(--brand-background)] border-gray-200">
+                    <DropdownMenuItem onClick={() => setLanguage("es")} className="text-[var(--brand-primary)] hover:bg-gray-50">
                       Español
                     </DropdownMenuItem>
-                    <DropdownMenuItem onClick={() => setLanguage("en")} className="text-black hover:bg-gray-50">
+                    <DropdownMenuItem onClick={() => setLanguage("en")} className="text-[var(--brand-primary)] hover:bg-gray-50">
                       English
                     </DropdownMenuItem>
-                  </DropdownMenuContent>
-                </DropdownMenu>
+                </DropdownMenuContent>
+              </DropdownMenu>
               </div>
             </div>
           </div>

--- a/components/providers.tsx
+++ b/components/providers.tsx
@@ -1,7 +1,7 @@
 "use client"
 
 import type React from "react"
-import { createContext, useContext, useState } from "react"
+import { createContext, useContext, useEffect, useState } from "react"
 
 type Language = "es" | "en"
 
@@ -16,6 +16,8 @@ interface AppContextType {
   setLanguage: (lang: Language) => void
   user: User | null
   setUser: (user: User | null) => void
+  settings: Record<string, string>
+  setSettings: (settings: Record<string, string>) => void
 }
 
 const AppContext = createContext<AppContextType | undefined>(undefined)
@@ -31,6 +33,51 @@ export function useApp() {
 export function Providers({ children }: { children: React.ReactNode }) {
   const [language, setLanguage] = useState<Language>("es")
   const [user, setUser] = useState<User | null>(null)
+  const [settings, setSettings] = useState<Record<string, string>>({})
 
-  return <AppContext.Provider value={{ language, setLanguage, user, setUser }}>{children}</AppContext.Provider>
+  useEffect(() => {
+    fetch("/api/settings")
+      .then((res) => res.json())
+      .then((data: Array<{ key: string; value: string }>) => {
+        const map: Record<string, string> = {}
+        data.forEach((s) => {
+          map[s.key] = s.value
+          if (s.key === "contact_info") {
+            try {
+              const parsed = JSON.parse(s.value)
+              Object.entries(parsed).forEach(([k, v]) => {
+                map[`contact_${k}`] = String(v)
+              })
+            } catch {
+              /* ignore */
+            }
+          }
+        })
+        setSettings(map)
+        document.documentElement.style.setProperty(
+          "--brand-primary",
+          map.primary_color || "#000000",
+        )
+        document.documentElement.style.setProperty(
+          "--brand-secondary",
+          map.secondary_color || "#FFD700",
+        )
+        document.documentElement.style.setProperty(
+          "--brand-background",
+          map.background_color || "#FFFFFF",
+        )
+        document.documentElement.style.setProperty(
+          "--brand-loading-background",
+          map.loading_background_color || map.background_color || "#FFFFFF",
+        )
+        document.body.style.backgroundColor = map.background_color || "#FFFFFF"
+      })
+      .catch((err) => console.error("Error fetching settings:", err))
+  }, [])
+
+  return (
+    <AppContext.Provider value={{ language, setLanguage, user, setUser, settings, setSettings }}>
+      {children}
+    </AppContext.Provider>
+  )
 }

--- a/components/ui/oro-loading.tsx
+++ b/components/ui/oro-loading.tsx
@@ -1,7 +1,8 @@
 "use client"
 
-import { useState } from "react"
 import Image from "next/image"
+import { useState } from "react"
+import { useApp } from "@/components/providers"
 
 interface OroLoadingProps {
   fullScreen?: boolean
@@ -9,9 +10,13 @@ interface OroLoadingProps {
 }
 
 export function OroLoading({ fullScreen = true, className = "" }: OroLoadingProps) {
+  const { settings } = useApp()
+  const logoSrc = settings.logo_url || "/assets/negro.png"
+  const companyName = settings.company_name || "OroBoats"
+
   // Aseguramos que el componente ocupe toda la pantalla y tenga la máxima prioridad de z-index
   const containerClasses = fullScreen
-    ? "fixed inset-0 bg-white bg-opacity-95 backdrop-blur-sm z-[99999] flex items-center justify-center"
+    ? "fixed inset-0 bg-[var(--brand-loading-background)] bg-opacity-95 backdrop-blur-sm z-[99999] flex items-center justify-center"
     : "flex items-center justify-center p-8"
 
   return (
@@ -31,7 +36,7 @@ export function OroLoading({ fullScreen = true, className = "" }: OroLoadingProp
               cy="50"
               r="48"
               fill="none"
-              stroke="#d4af37"
+              stroke="var(--brand-secondary)"
               strokeWidth="3"
               strokeLinecap="round"
               strokeDasharray="301.6"
@@ -46,7 +51,7 @@ export function OroLoading({ fullScreen = true, className = "" }: OroLoadingProp
               cy="50"
               r="48"
               fill="none"
-              stroke="#f4d03f"
+              stroke="var(--brand-secondary)"
               strokeWidth="1.5"
               strokeLinecap="round"
               strokeDasharray="301.6"
@@ -68,15 +73,15 @@ export function OroLoading({ fullScreen = true, className = "" }: OroLoadingProp
           <div className="absolute inset-0 flex items-center justify-center">
             <div className="relative w-32 h-32 animate-float-logo">
               <Image
-                src="/assets/negro.png"
-                alt="OroBoats Logo"
+                src={logoSrc}
+                alt={`${companyName} Logo`}
                 fill
                 className="object-contain drop-shadow-lg"
                 priority
               />
 
               {/* Efecto de brillo sutil alrededor del logo */}
-              <div className="absolute inset-0 bg-gradient-to-r from-transparent via-gold/10 to-transparent animate-shimmer"></div>
+              <div className="absolute inset-0 bg-gradient-to-r from-transparent via-[color:var(--brand-secondary)]/10 to-transparent animate-shimmer"></div>
             </div>
           </div>
         </div>

--- a/lib/db/queries.ts
+++ b/lib/db/queries.ts
@@ -285,12 +285,15 @@ export async function getSetting(key: string) {
 }
 
 export async function updateSetting(key: string, value: unknown, description?: string) {
+  const serialized =
+    typeof value === "string" ? value : value === undefined ? "" : JSON.stringify(value)
+
   return await db
     .insert(settings)
-    .values({ key, value: value === undefined ? "" : String(value), description })
+    .values({ key, value: serialized, description })
     .onConflictDoUpdate({
       target: settings.key,
-      set: { value: value === undefined ? "" : String(value), updatedAt: new Date() },
+      set: { value: serialized, updatedAt: new Date() },
     })
 }
 


### PR DESCRIPTION
## Summary
- add admin controls for two button color palettes and separate loading/page backgrounds
- centralize button styling with CSS utility classes and overrides
- allow OroLoading backdrop to use dedicated brand color

## Testing
- `npm test` (fails: Missing script "test")
- `npm run lint` (fails: various lint errors across repo)


------
https://chatgpt.com/codex/tasks/task_e_68b639758f0c83319cbf2f3bad73ea36