### PR TITLE
feat: make contact info editable across site

### DIFF
--- a/app/contact/page.tsx
+++ b/app/contact/page.tsx
@@ -80,8 +80,13 @@ const translations = {
 }
 
 export default function ContactPage() {
-  const { language } = useApp()
+  const { language, settings } = useApp()
   const t = translations[language]
+  const contactPhone = settings.contact_phone || t.info.phone
+  const contactEmail = settings.contact_email || t.info.email
+  const contactWhatsapp = settings.contact_whatsapp || t.info.whatsapp
+  const contactAddress = settings.contact_address || t.info.address
+  const contactCity = settings.contact_city || t.info.city
   const [formData, setFormData] = useState({
     name: "",
     email: "",
@@ -169,7 +174,7 @@ export default function ContactPage() {
                   <Phone className="h-6 w-6 text-gold mt-1" />
                   <div>
                     <h3 className="font-semibold text-gray-900">{t.phone}</h3>
-                    <p className="text-gray-600">{t.info.phone}</p>
+                    <p className="text-gray-600">{contactPhone}</p>
                   </div>
                 </div>
 
@@ -177,7 +182,7 @@ export default function ContactPage() {
                   <Mail className="h-6 w-6 text-gold mt-1" />
                   <div>
                     <h3 className="font-semibold text-gray-900">{t.email}</h3>
-                    <p className="text-gray-600">{t.info.email}</p>
+                    <p className="text-gray-600">{contactEmail}</p>
                   </div>
                 </div>
 
@@ -185,7 +190,7 @@ export default function ContactPage() {
                   <MessageCircle className="h-6 w-6 text-gold mt-1" />
                   <div>
                     <h3 className="font-semibold text-gray-900">{t.whatsapp}</h3>
-                    <p className="text-gray-600">{t.info.whatsapp}</p>
+                    <p className="text-gray-600">{contactWhatsapp}</p>
                   </div>
                 </div>
 
@@ -193,8 +198,8 @@ export default function ContactPage() {
                   <MapPin className="h-6 w-6 text-gold mt-1" />
                   <div>
                     <h3 className="font-semibold text-gray-900">{t.address}</h3>
-                    <p className="text-gray-600">{t.info.address}</p>
-                    <p className="text-gray-600">{t.info.city}</p>
+                    <p className="text-gray-600">{contactAddress}</p>
+                    <p className="text-gray-600">{contactCity}</p>
                   </div>
                 </div>
 

--- a/components/admin/settings-management.tsx
+++ b/components/admin/settings-management.tsx
@@ -21,6 +21,8 @@ interface ContactInfo {
   phone: string
   email: string
   address: string
+  city: string
+  whatsapp: string
 }
 
 interface BusinessHours {
@@ -38,6 +40,8 @@ export function SettingsManagement() {
     phone: "",
     email: "",
     address: "",
+    city: "",
+    whatsapp: "",
   })
   const [businessHours, setBusinessHours] = useState<BusinessHours>({
     start: "",
@@ -70,7 +74,8 @@ export function SettingsManagement() {
         switch (setting.key) {
           case "contact_info":
             try {
-              setContactInfo(JSON.parse(setting.value as string))
+              const parsed = JSON.parse(setting.value as string)
+              setContactInfo((prev) => ({ ...prev, ...parsed }))
             } catch {
               /* ignore */
             }
@@ -329,12 +334,32 @@ export function SettingsManagement() {
             </div>
 
             <div>
+              <label className="block text-sm font-medium text-gray-700 mb-2">WhatsApp</label>
+              <Input
+                value={contactInfo.whatsapp}
+                onChange={(e) => setContactInfo({ ...contactInfo, whatsapp: e.target.value })}
+                placeholder="+34 123 456 789"
+                className="bg-gray-50 border-gray-200"
+              />
+            </div>
+
+            <div>
               <label className="block text-sm font-medium text-gray-700 mb-2">Dirección</label>
               <Textarea
                 value={contactInfo.address}
                 onChange={(e) => setContactInfo({ ...contactInfo, address: e.target.value })}
                 placeholder="Puerto Marina Valencia, Muelle VIP 15"
                 rows={3}
+                className="bg-gray-50 border-gray-200"
+              />
+            </div>
+
+            <div>
+              <label className="block text-sm font-medium text-gray-700 mb-2">Ciudad</label>
+              <Input
+                value={contactInfo.city}
+                onChange={(e) => setContactInfo({ ...contactInfo, city: e.target.value })}
+                placeholder="La Herradura, Granada"
                 className="bg-gray-50 border-gray-200"
               />
             </div>

--- a/components/boats/boats-section.tsx
+++ b/components/boats/boats-section.tsx
@@ -646,19 +646,26 @@ function LicenseWarningModal({
 
 // Widget de contacto flotante
 function FloatingContactWidget({ t }: { t: Translations }) {
+  const { settings } = useApp()
   const [isOpen, setIsOpen] = useState(false)
 
+  const contactPhone = settings.contact_phone || "+34 655 52 79 88"
+  const contactWhatsapp = settings.contact_whatsapp || "+34 643 44 23 64"
+  const contactEmail = settings.contact_email || "info@oroboats.com"
+  const cleanPhone = contactPhone.replace(/\s+/g, "")
+  const cleanWhatsapp = contactWhatsapp.replace(/\s+/g, "").replace(/^\+/, "")
+
   const handleCall = () => {
-    window.location.href = "tel:+34655527988"
+    window.location.href = `tel:${cleanPhone}`
   }
 
   const handleWhatsApp = () => {
     const message = encodeURIComponent("Hola, necesito ayuda con el alquiler de embarcaciones")
-    window.open(`https://wa.me/34643442364?text=${message}`, "_blank")
+    window.open(`https://wa.me/${cleanWhatsapp}?text=${message}`, "_blank")
   }
 
   const handleEmail = () => {
-    window.location.href = "mailto:info@oroboats.com"
+    window.location.href = `mailto:${contactEmail}`
   }
 
   return (
@@ -707,7 +714,7 @@ function FloatingContactWidget({ t }: { t: Translations }) {
                 <Phone className="h-4 w-4 sm:h-5 sm:w-5 mr-2 sm:mr-3 flex-shrink-0" />
                 <div className="text-left flex-1">
                   <div className="font-semibold text-sm sm:text-base">{t.call}</div>
-                  <div className="text-xs sm:text-sm opacity-90">+34 655 52 79 88</div>
+                  <div className="text-xs sm:text-sm opacity-90">{contactPhone}</div>
                 </div>
               </button>
               <button
@@ -717,7 +724,7 @@ function FloatingContactWidget({ t }: { t: Translations }) {
                 <MessageCircle className="h-4 w-4 sm:h-5 sm:w-5 mr-2 sm:mr-3 flex-shrink-0" />
                 <div className="text-left flex-1">
                   <div className="font-semibold text-sm sm:text-base">{t.whatsapp}</div>
-                  <div className="text-xs sm:text-sm opacity-90">+34 643 44 23 64</div>
+                  <div className="text-xs sm:text-sm opacity-90">{contactWhatsapp}</div>
                 </div>
               </button>
               <button
@@ -727,7 +734,7 @@ function FloatingContactWidget({ t }: { t: Translations }) {
                 <Mail className="h-4 w-4 sm:h-5 sm:w-5 mr-2 sm:mr-3 flex-shrink-0" />
                 <div className="text-left flex-1">
                   <div className="font-semibold text-sm sm:text-base">{t.email}</div>
-                  <div className="text-xs sm:text-sm opacity-90">info@oroboats.com</div>
+                  <div className="text-xs sm:text-sm opacity-90">{contactEmail}</div>
                 </div>
               </button>
             </div>

--- a/components/home/contact-section.tsx
+++ b/components/home/contact-section.tsx
@@ -47,8 +47,11 @@ const translations = {
 }
 
 export function ContactSection() {
-  const { language } = useApp()
+  const { language, settings } = useApp()
   const t = translations[language]
+  const contactPhone = settings.contact_phone || "+34 655 52 79 88"
+  const contactEmail = settings.contact_email || "info@oroboats.com"
+  const contactWhatsapp = settings.contact_whatsapp || "+34 643 44 23 64"
 
   const [formData, setFormData] = useState({
     name: "",
@@ -116,7 +119,7 @@ export function ContactSection() {
                 </div>
                 <div>
                   <p className="text-gray-500 text-sm">{t.phone}</p>
-                  <p className="text-black text-lg font-medium">+34 655 52 79 88</p>
+                  <p className="text-black text-lg font-medium">{contactPhone}</p>
                 </div>
               </div>
 
@@ -126,7 +129,7 @@ export function ContactSection() {
                 </div>
                 <div>
                   <p className="text-gray-500 text-sm">{t.emailLabel}</p>
-                  <p className="text-black text-lg font-medium">info@oroboats.com</p>
+                  <p className="text-black text-lg font-medium">{contactEmail}</p>
                 </div>
               </div>
 
@@ -136,7 +139,7 @@ export function ContactSection() {
                 </div>
                 <div>
                   <p className="text-gray-500 text-sm">{t.whatsapp}</p>
-                  <p className="text-black text-lg font-medium">+34 643 44 23 64</p>
+                  <p className="text-black text-lg font-medium">{contactWhatsapp}</p>
                 </div>
               </div>
             </CardContent>

--- a/components/home/location-section.tsx
+++ b/components/home/location-section.tsx
@@ -28,8 +28,11 @@ const translations = {
 }
 
 export function LocationSection() {
-  const { language } = useApp()
+  const { language, settings } = useApp()
   const t = translations[language]
+  const address = settings.contact_address || t.address
+  const city = settings.contact_city || t.location
+  const phone = settings.contact_phone || t.phone
 
   const openInGoogleMaps = () => {
     window.open(
@@ -54,8 +57,8 @@ export function LocationSection() {
                 <MapPin className="h-6 w-6 text-black" />
               </div>
               <div>
-                <h3 className="text-xl font-bold text-black mb-2">{t.address}</h3>
-                <p className="text-gray-600">{t.location}</p>
+                <h3 className="text-xl font-bold text-black mb-2">{address}</h3>
+                <p className="text-gray-600">{city}</p>
               </div>
             </div>
 
@@ -75,18 +78,8 @@ export function LocationSection() {
               </div>
               <div>
                 <h3 className="text-xl font-bold text-black mb-2">Contacto</h3>
-                <p className="text-gray-600">{t.phone}</p>
+                <p className="text-gray-600">{phone}</p>
               </div>
-            </div>
-
-            <div className="pt-4">
-              <button
-                onClick={openInGoogleMaps}
-                className="inline-flex items-center px-6 py-3 bg-gold hover:bg-yellow-500 text-black font-medium rounded-lg transition-colors duration-200"
-              >
-                <ExternalLink className="h-5 w-5 mr-2" />
-                {t.openInMaps}
-              </button>
             </div>
           </div>
 

--- a/lib/db/seed.ts
+++ b/lib/db/seed.ts
@@ -142,7 +142,9 @@ async function seed() {
         value: {
           phone: "+34 123 456 789",
           email: "info@oroboats.com",
+          whatsapp: "+34 987 654 321",
           address: "Puerto Marina Valencia, Muelle VIP 15",
+          city: "Valencia, España",
         },
         description: "Información de contacto del negocio",
       },


### PR DESCRIPTION
## Summary
- allow editing phone, email, whatsapp and city from admin settings
- use saved contact data across contact and location components
- restore static clickable Google Maps image instead of styled button

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint` *(fails: many lint errors)*

------
https://chatgpt.com/codex/tasks/task_e_68b644c58c8c8331b73d28ff379c8a04